### PR TITLE
TextRenderer Failure Handling, physics debug and Game checks

### DIFF
--- a/JokEngine/Game.cpp
+++ b/JokEngine/Game.cpp
@@ -119,7 +119,12 @@ void Game::Init()
 		textService->Load("fonts/emulogic.TTF", 24);
 		RegisterTextRendererService(textService);
 	}
-
+	ASSERT(text);
+	ASSERT(audio);
+	ASSERT(cameras);
+	ASSERT(time);
+	ASSERT(physics);
+	ASSERT(renderer);
 }
 void Game::Loop()
 {

--- a/JokEngine/PhysicsDebug.cpp
+++ b/JokEngine/PhysicsDebug.cpp
@@ -8,27 +8,32 @@ PhysicsDebug::PhysicsDebug()
 }
 glm::vec2 PhysicsDebug::GetGravity()
 {
+	std::cout << "Getting gravity X:" <<  phys->GetGravity().x << " Y:" << phys->GetGravity().y << std::endl;
 	return phys->GetGravity();
 }
 void PhysicsDebug::SetGravity(glm::vec2 gravity)
 {
+	std::cout << "Setting gravity X:" << gravity.x << " Y:" << gravity.y << std::endl;
 	phys->SetGravity(gravity);
 }
 b2Body* PhysicsDebug::RegisterBody(PhysicBody* pb,glm::vec2 position, GLboolean isKinematic, GLboolean isGravity, GLfloat rotation, GLfloat angularDrag, GLfloat drag, GLint mass, GLboolean isRotation)
 {
+	std::cout << "Registering body at position " << " X:" << position.x << " Y:" << position.y;
 	return phys->RegisterBody(pb,position, isKinematic, isGravity, rotation, angularDrag, drag, mass, isRotation);
 }
 b2Fixture* PhysicsDebug::RegisterFixtureBox(b2Body *body,Collider* col, glm::vec2 size,GLboolean sensor, glm::vec2 offset, std::string layerName)
 {
+	std::cout << "Registering FixtureBox at position " << " X:" << body->GetPosition().x << " Y:" << body->GetPosition().x;
 	return(phys->RegisterFixtureBox(body, col, size,sensor, offset, layerName));
 }
 b2Fixture* PhysicsDebug::RegisterFixtureCircle(b2Body *body, Collider* col, GLfloat radius,GLboolean sensor, glm::vec2 offset, std::string layerName)
 {
+	std::cout << "Registering FixtureCircle at position " << " X:" << body->GetPosition().x << " Y:" << body->GetPosition().x;
 	return phys->RegisterFixtureCircle(body, col,  radius, sensor, offset,  layerName);
 }
 b2Fixture* PhysicsDebug::RegisterFixtureEdge(b2Body *body, Collider* col, glm::vec2 pointA, glm::vec2 pointB, std::string layerName)
 {
-
+	std::cout << "Registering FixtureEdge at position " << " X:" << body->GetPosition().x << " Y:" << body->GetPosition().x;
 	return phys->RegisterFixtureEdge(body, col,pointA, pointB, layerName);
 }
 void PhysicsDebug::SetMaskBits(std::string layerName, std::string otherLayer, GLboolean isColliding)

--- a/JokEngine/TextRenderer.cpp
+++ b/JokEngine/TextRenderer.cpp
@@ -34,11 +34,12 @@ void TextRenderer::Load(std::string font, GLuint fontSize)
 	FT_Library ft;
 	if (FT_Init_FreeType(&ft)) 
 		std::cout << "ERROR::FREETYPE: Could not init FreeType Library" << std::endl;
+	return;
 	// Load font as face
 	FT_Face face;
 	if (FT_New_Face(ft, font.c_str(), 0, &face))
 		std::cout << "ERROR::FREETYPE: Failed to load font" << std::endl;
-
+	return;
 	FT_Set_Pixel_Sizes(face, 0, fontSize);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 


### PR DESCRIPTION
Fixed a problem where not finding the specified font would crash the application
Added some outputs to the physic service when in debug mode
added some assertions to make sure every service is loaded after the game initialisation